### PR TITLE
Add FastAPI gateway with config-driven model routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: up down logs
+
+up:
+docker compose up -d
+
+down:
+docker compose down
+
+logs:
+docker compose logs -f

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt \
+    && useradd -m appuser \
+    && chown -R appuser /app
+COPY . /app
+USER appuser
+ENV MODELS_CONFIG=/app/../config/models.yaml
+CMD ["uvicorn", "api.server:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.1
+httpx==0.27.0
+uvicorn==0.29.0
+pyyaml==6.0.1

--- a/api/server.py
+++ b/api/server.py
@@ -1,0 +1,167 @@
+import os
+import json
+import time
+import logging
+from typing import Any, Dict
+from uuid import uuid4
+
+import yaml
+import httpx
+from fastapi import FastAPI, HTTPException, Request, Depends, Header
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel, Field
+
+CONFIG_PATH = os.environ.get("MODELS_CONFIG", "config/models.yaml")
+
+logger = logging.getLogger("gateway")
+logging.basicConfig(level=logging.INFO, format='%(message)s')
+
+app = FastAPI()
+
+
+def load_config() -> Dict[str, Dict[str, Any]]:
+    try:
+        with open(CONFIG_PATH, 'r') as f:
+            data = yaml.safe_load(f) or {}
+        models = data.get('models', {})
+        app.state.models = models
+        return models
+    except FileNotFoundError:
+        app.state.models = {}
+        return {}
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    load_config()
+    limits = httpx.Limits(max_connections=100, max_keepalive_connections=20)
+    transport = httpx.AsyncHTTPTransport(retries=3)
+    timeout = httpx.Timeout(10.0)
+    app.state.client = httpx.AsyncClient(timeout=timeout, limits=limits, transport=transport)
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    await app.state.client.aclose()
+
+
+class ChatMessage(BaseModel):
+    role: str
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str
+    messages: list[ChatMessage]
+    stream: bool = False
+
+    class Config:
+        extra = "allow"
+
+
+class CompletionRequest(BaseModel):
+    model: str
+    prompt: Any
+    stream: bool = False
+
+    class Config:
+        extra = "allow"
+
+
+class EmbeddingRequest(BaseModel):
+    model: str
+    input: Any
+
+    class Config:
+        extra = "allow"
+
+
+def verify_api_key(authorization: str | None = Header(default=None)) -> None:
+    api_key = os.environ.get("API_KEY")
+    if api_key:
+        if authorization is None or not authorization.startswith("Bearer "):
+            raise HTTPException(status_code=401, detail="Missing token")
+        token = authorization.split(" ", 1)[1]
+        if token != api_key:
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+
+def get_model_config(model: str) -> Dict[str, Any]:
+    models = getattr(app.state, "models", {})
+    if model not in models:
+        suggestions = list(models.keys())
+        raise HTTPException(status_code=404, detail={"error": "Unknown model", "suggestions": suggestions})
+    return models[model]
+
+
+async def proxy_request(path: str, payload: Dict[str, Any], stream: bool, model_cfg: Dict[str, Any], request: Request) -> StreamingResponse | JSONResponse:
+    url = model_cfg["service_url"] + path
+    headers = dict(request.headers)
+    headers.pop("host", None)
+    if stream:
+        async def event_stream() -> Any:
+            async with app.state.client.stream("POST", url, json=payload, headers=headers) as resp:
+                async for chunk in resp.aiter_raw():
+                    yield chunk
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
+    resp = await app.state.client.post(url, json=payload, headers=headers)
+    return JSONResponse(content=resp.json(), status_code=resp.status_code)
+
+
+@app.middleware("http")
+async def log_middleware(request: Request, call_next):
+    start = time.time()
+    trace_id = uuid4().hex
+    model = "-"
+    body_bytes = await request.body()
+    if body_bytes:
+        try:
+            body_json = json.loads(body_bytes)
+            model = body_json.get("model", "-")
+        except Exception:
+            pass
+        request._body = body_bytes
+    response = await call_next(request)
+    latency = (time.time() - start) * 1000
+    log = {
+        "method": request.method,
+        "path": request.url.path,
+        "model": model,
+        "status": response.status_code,
+        "latency_ms": round(latency, 2),
+        "trace_id": trace_id,
+    }
+    logger.info(json.dumps(log))
+    return response
+
+
+@app.get("/.well-known/health")
+async def health() -> Dict[str, Any]:
+    models = getattr(app.state, "models", {})
+    return {"status": "ok", "models": list(models.keys())}
+
+
+@app.post("/admin/reload")
+async def admin_reload() -> Dict[str, str]:
+    load_config()
+    return {"status": "reloaded"}
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(req: ChatCompletionRequest, request: Request, _: None = Depends(verify_api_key)):
+    model_cfg = get_model_config(req.model)
+    return await proxy_request("/v1/chat/completions", req.model_dump(), req.stream, model_cfg, request)
+
+
+@app.post("/v1/completions")
+async def completions(req: CompletionRequest, request: Request, _: None = Depends(verify_api_key)):
+    model_cfg = get_model_config(req.model)
+    return await proxy_request("/v1/completions", req.model_dump(), req.stream, model_cfg, request)
+
+
+@app.post("/v1/embeddings")
+async def embeddings(req: EmbeddingRequest, request: Request, _: None = Depends(verify_api_key)):
+    model_cfg = get_model_config(req.model)
+    if not model_cfg.get("embeddings", False):
+        raise HTTPException(status_code=400, detail="Model does not support embeddings")
+    return await proxy_request("/v1/embeddings", req.model_dump(), False, model_cfg, request)

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,0 +1,6 @@
+models:
+  test-model:
+    service_url: "http://localhost:8001"
+  embedding-model:
+    service_url: "http://localhost:8002"
+    embeddings: true

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from fastapi.testclient import TestClient
+
+from api.server import app, load_config
+
+os.environ["API_KEY"] = "test"
+
+client = TestClient(app)
+
+
+def test_health():
+    load_config()
+    resp = client.get("/.well-known/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "test-model" in body["models"]
+
+
+def test_unknown_model():
+    payload = {"model": "unknown", "messages": [{"role": "user", "content": "hi"}]}
+    resp = client.post("/v1/chat/completions", json=payload, headers={"Authorization": "Bearer test"})
+    assert resp.status_code == 404
+    body = resp.json()
+    assert "suggestions" in body["detail"]


### PR DESCRIPTION
## Summary
- implement FastAPI gateway with config-driven model routing, streaming proxy, auth, logging, and health reload endpoints
- provide Dockerfile, requirements, Makefile, and sample model config
- add unit tests for health endpoint and unknown model errors

## Testing
- `python -m py_compile api/server.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689772d0a7c0832d96146dd40f55459f