### PR TITLE
feat: add model registry and gateway endpoints

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1,0 +1,369 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/healthz": {
+      "get": {
+        "summary": "Health",
+        "operationId": "health_healthz_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Health Healthz Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/models": {
+      "get": {
+        "summary": "List Models",
+        "operationId": "list_models_v1_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response List Models V1 Models Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/reload": {
+      "post": {
+        "summary": "Admin Reload",
+        "operationId": "admin_reload_admin_reload_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object",
+                  "title": "Response Admin Reload Admin Reload Post"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/chat/completions": {
+      "post": {
+        "summary": "Chat Completions",
+        "operationId": "chat_completions_v1_chat_completions_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChatCompletionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/completions": {
+      "post": {
+        "summary": "Completions",
+        "operationId": "completions_v1_completions_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompletionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/embeddings": {
+      "post": {
+        "summary": "Embeddings",
+        "operationId": "embeddings_v1_embeddings_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmbeddingRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ChatCompletionRequest": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "type": "array",
+            "title": "Messages"
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "default": false
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "model",
+          "messages"
+        ],
+        "title": "ChatCompletionRequest"
+      },
+      "ChatMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "title": "Role"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          }
+        },
+        "type": "object",
+        "required": [
+          "role",
+          "content"
+        ],
+        "title": "ChatMessage"
+      },
+      "CompletionRequest": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "prompt": {
+            "title": "Prompt"
+          },
+          "stream": {
+            "type": "boolean",
+            "title": "Stream",
+            "default": false
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "model",
+          "prompt"
+        ],
+        "title": "CompletionRequest"
+      },
+      "EmbeddingRequest": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "input": {
+            "title": "Input"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "model",
+          "input"
+        ],
+        "title": "EmbeddingRequest"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/api/registry.py
+++ b/api/registry.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+
+
+class ModelConfig(BaseModel):
+    """Configuration for a single model backend."""
+
+    service_url: str
+    embeddings: bool = False
+    headers: Dict[str, str] = Field(default_factory=dict)
+    env: Dict[str, str] = Field(default_factory=dict)
+    limits: Dict[str, int] = Field(default_factory=dict)
+
+
+class ModelsConfig(BaseModel):
+    models: Dict[str, ModelConfig] = Field(default_factory=dict)
+
+
+class Registry:
+    """Hot-reloading model registry backed by a YAML file."""
+
+    def __init__(self, path: str) -> None:
+        self.path = Path(path)
+        self.mtime: float = 0.0
+        self.models: Dict[str, ModelConfig] = {}
+        self.load()
+
+    def load(self) -> None:
+        """Load and validate the config file."""
+        data = yaml.safe_load(self.path.read_text()) if self.path.exists() else {}
+        cfg = ModelsConfig(**data)
+        self.models = cfg.models
+        self.mtime = self.path.stat().st_mtime
+        # Apply environment variables defined under each model.
+        for model in self.models.values():
+            for key, value in model.env.items():
+                os.environ.setdefault(key, value)
+
+    def maybe_reload(self) -> None:
+        """Reload the config file if it has changed."""
+        if not self.path.exists():
+            return
+        mtime = self.path.stat().st_mtime
+        if mtime <= self.mtime:
+            return
+        try:
+            self.load()
+        except ValidationError as exc:  # keep old config on error
+            # re-raise to allow caller to log or handle if desired
+            raise exc
+
+
+__all__ = ["ModelConfig", "Registry"]

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,6 +1,10 @@
 models:
   test-model:
     service_url: "http://localhost:8001"
+    headers:
+      x-test: "1"
+    limits:
+      max_tokens: 1000
   embedding-model:
     service_url: "http://localhost:8002"
     embeddings: true

--- a/config/secrets.env
+++ b/config/secrets.env
@@ -1,0 +1,2 @@
+# Environment variables for ModelTainer
+API_KEY=test

--- a/docs/module-plan.md
+++ b/docs/module-plan.md
@@ -14,16 +14,16 @@ No training or full OpenAI platform clone; scope limited to `/v1/models`, `/v1/c
 
 ## Modules
 ### M1. API Gateway
-- Endpoints: `/healthz`, `/v1/models`, `/v1/chat/completions` (+`/v1/completions`).
-- SSE streaming, auth, routing, timeouts/retries, JSON logs, OpenAI error schema.
-- Deliverables: gateway app, Dockerfile, openapi.json, proxy snippets.
+- Endpoints: `/healthz`, `/v1/models`, `/v1/chat/completions` (plus `/v1/completions`).
+- Supports SSE streaming, Bearer auth, per-model routing, request timeouts/retries, JSON logs and OpenAI-compatible error schema.
+- Deliverables: gateway app, Dockerfile, `openapi.json`, proxy snippets.
 - Acceptance: curl/Python streaming through both backends.
 
 ### M2. Model Registry
 - YAML schema for model name, backend URL, limits, optional env/headers.
-- Hot reload with validation.
+- Hot reload with validation via Pydantic models.
 - Deliverables: Pydantic schema, loader, tests, sample config & secrets env.
-- Acceptance: edit config → live update; invalid configs rejected.
+- Acceptance: editing the config file triggers live update; invalid configs are rejected.
 
 ### M3. vLLM Backend (GPU)
 - Compose service for CUDA or ROCm with persistent HF cache and health checks.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,11 +15,20 @@ client = TestClient(app)
 
 def test_health():
     load_config()
-    resp = client.get("/.well-known/health")
+    resp = client.get("/healthz")
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "ok"
     assert "test-model" in body["models"]
+
+
+def test_models_endpoint():
+    load_config()
+    resp = client.get("/v1/models")
+    assert resp.status_code == 200
+    body = resp.json()
+    ids = [m["id"] for m in body["data"]]
+    assert "test-model" in ids
 
 
 def test_unknown_model():
@@ -27,4 +36,4 @@ def test_unknown_model():
     resp = client.post("/v1/chat/completions", json=payload, headers={"Authorization": "Bearer test"})
     assert resp.status_code == 404
     body = resp.json()
-    assert "suggestions" in body["detail"]
+    assert "suggestions" in body["error"]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,29 @@
+import time
+
+import pytest
+from pydantic import ValidationError
+
+from api.registry import Registry
+
+
+def test_registry_reload(tmp_path):
+    cfg = tmp_path / "models.yaml"
+    cfg.write_text("models:\n  a:\n    service_url: http://one\n")
+    reg = Registry(str(cfg))
+    assert "a" in reg.models
+    time.sleep(0.1)
+    cfg.write_text("models:\n  b:\n    service_url: http://two\n")
+    reg.maybe_reload()
+    assert "b" in reg.models
+    assert "a" not in reg.models
+
+
+def test_registry_invalid(tmp_path):
+    cfg = tmp_path / "models.yaml"
+    cfg.write_text("models:\n  a:\n    service_url: http://one\n")
+    reg = Registry(str(cfg))
+    time.sleep(0.1)
+    cfg.write_text("models:\n  bad:\n    foo: bar\n")
+    with pytest.raises(ValidationError):
+        reg.maybe_reload()
+    assert "a" in reg.models


### PR DESCRIPTION
## Summary
- add hot-reloading Pydantic model registry
- expose `/healthz` and `/v1/models` endpoints with OpenAI-style errors
- include sample config, secrets env, and generated OpenAPI spec

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68977e6f44b8832db2273f9c59793875