### PR TITLE
Remove legacy /v1/completions endpoint

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -121,60 +121,6 @@
         }
       }
     },
-    "/v1/completions": {
-      "post": {
-        "summary": "Completions",
-        "operationId": "completions_v1_completions_post",
-        "parameters": [
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CompletionRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/embeddings": {
       "post": {
         "summary": "Embeddings",
@@ -276,29 +222,6 @@
           "content"
         ],
         "title": "ChatMessage"
-      },
-      "CompletionRequest": {
-        "properties": {
-          "model": {
-            "type": "string",
-            "title": "Model"
-          },
-          "prompt": {
-            "title": "Prompt"
-          },
-          "stream": {
-            "type": "boolean",
-            "title": "Stream",
-            "default": false
-          }
-        },
-        "additionalProperties": true,
-        "type": "object",
-        "required": [
-          "model",
-          "prompt"
-        ],
-        "title": "CompletionRequest"
       },
       "EmbeddingRequest": {
         "properties": {

--- a/api/server.py
+++ b/api/server.py
@@ -63,15 +63,6 @@ class ChatCompletionRequest(BaseModel):
         extra = "allow"
 
 
-class CompletionRequest(BaseModel):
-    model: str
-    prompt: Any
-    stream: bool = False
-
-    class Config:
-        extra = "allow"
-
-
 class EmbeddingRequest(BaseModel):
     model: str
     input: Any
@@ -198,12 +189,6 @@ async def admin_reload() -> Dict[str, str]:
 async def chat_completions(req: ChatCompletionRequest, request: Request, _: None = Depends(verify_api_key)):
     model_cfg = get_model_config(req.model)
     return await proxy_request("/v1/chat/completions", req.model_dump(), req.stream, model_cfg, request)
-
-
-@app.post("/v1/completions")
-async def completions(req: CompletionRequest, request: Request, _: None = Depends(verify_api_key)):
-    model_cfg = get_model_config(req.model)
-    return await proxy_request("/v1/completions", req.model_dump(), req.stream, model_cfg, request)
 
 
 @app.post("/v1/embeddings")

--- a/docs/module-plan.md
+++ b/docs/module-plan.md
@@ -4,7 +4,7 @@
 One command to deploy multiple LLM backends behind an OpenAI-compatible gateway. Supports vLLM on NVIDIA/AMD GPUs and llama.cpp on CPU/ARM with safe defaults, observability, and Slurm+Apptainer portability.
 
 ## Non-Goals
-No training or full OpenAI platform clone; scope limited to `/v1/models`, `/v1/chat/completions` (optional `/v1/completions`) and streaming SSE.
+No training or full OpenAI platform clone; scope limited to `/v1/models`, `/v1/chat/completions` and streaming SSE.
 
 ## Architecture
 ```
@@ -14,7 +14,7 @@ No training or full OpenAI platform clone; scope limited to `/v1/models`, `/v1/c
 
 ## Modules
 ### M1. API Gateway
-- Endpoints: `/healthz`, `/v1/models`, `/v1/chat/completions` (plus `/v1/completions`).
+- Endpoints: `/healthz`, `/v1/models`, `/v1/chat/completions`.
 - Supports SSE streaming, Bearer auth, per-model routing, request timeouts/retries, JSON logs and OpenAI-compatible error schema.
 - Deliverables: gateway app, Dockerfile, `openapi.json`, proxy snippets.
 - Acceptance: curl/Python streaming through both backends.


### PR DESCRIPTION
## Summary
- drop unused `/v1/completions` endpoint and request model
- regenerate `openapi.json` to match new routes
- update module plan to reflect streamlined API Gateway

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f4c8daf8832db1af8c23b6d23661