### PR TITLE
feat: add backend aware model registry

### DIFF
--- a/api/registry.py
+++ b/api/registry.py
@@ -1,21 +1,42 @@
 from __future__ import annotations
 
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Dict
 
 import yaml
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    HttpUrl,
+    PositiveInt,
+    ValidationError,
+)
+
+
+class Backend(str, Enum):
+    """Supported model backend implementations."""
+
+    VLLM = "vllm"
+    LLAMACPP = "llamacpp"
 
 
 class ModelConfig(BaseModel):
     """Configuration for a single model backend."""
 
-    service_url: str
+    backend_url: HttpUrl = Field(validation_alias=AliasChoices("backend_url", "service_url"))
+    backend: Backend = Backend.VLLM
     embeddings: bool = False
     headers: Dict[str, str] = Field(default_factory=dict)
     env: Dict[str, str] = Field(default_factory=dict)
-    limits: Dict[str, int] = Field(default_factory=dict)
+    limits: Dict[str, PositiveInt] = Field(default_factory=dict)
+
+    model_config = {
+        "extra": "forbid",
+        "populate_by_name": True,
+    }
 
 
 class ModelsConfig(BaseModel):
@@ -56,4 +77,4 @@ class Registry:
             raise exc
 
 
-__all__ = ["ModelConfig", "Registry"]
+__all__ = ["Backend", "ModelConfig", "Registry"]

--- a/api/server.py
+++ b/api/server.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.exception_handlers import http_exception_handler as fastapi_http_exception_handler
 from pydantic import BaseModel
 
-from .registry import Registry, ModelConfig
+from .registry import ModelConfig, Registry
 
 CONFIG_PATH = os.environ.get("MODELS_CONFIG", "config/models.yaml")
 
@@ -118,7 +118,7 @@ def get_model_config(model: str) -> ModelConfig:
 
 
 async def proxy_request(path: str, payload: Dict[str, Any], stream: bool, model_cfg: ModelConfig, request: Request) -> StreamingResponse | JSONResponse:
-    url = model_cfg.service_url + path
+    url = model_cfg.backend_url + path
     headers = dict(request.headers)
     headers.pop("host", None)
     headers.update(model_cfg.headers)

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,10 +1,12 @@
 models:
   test-model:
-    service_url: "http://localhost:8001"
+    backend: vllm
+    backend_url: "http://localhost:8001"
     headers:
       x-test: "1"
     limits:
       max_tokens: 1000
   embedding-model:
-    service_url: "http://localhost:8002"
+    backend: llamacpp
+    backend_url: "http://localhost:8002"
     embeddings: true

--- a/docs/module-plan.md
+++ b/docs/module-plan.md
@@ -74,11 +74,11 @@ version: 1
 models:
   - name: llama3-8b-instruct
     backend: vllm
-    endpoint: http://vllm-1:8000/v1
+    backend_url: http://vllm-1:8000
     format: chat_completions
   - name: q4-cpu-llama
     backend: llamacpp
-    endpoint: http://llama-cpp-1:8080/v1
+    backend_url: http://llama-cpp-1:8080
     format: chat_completions
 ```
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,3 +1,4 @@
+import os
 import time
 
 import pytest
@@ -8,11 +9,11 @@ from api.registry import Registry
 
 def test_registry_reload(tmp_path):
     cfg = tmp_path / "models.yaml"
-    cfg.write_text("models:\n  a:\n    service_url: http://one\n")
+    cfg.write_text("models:\n  a:\n    backend_url: http://one\n")
     reg = Registry(str(cfg))
     assert "a" in reg.models
     time.sleep(0.1)
-    cfg.write_text("models:\n  b:\n    service_url: http://two\n")
+    cfg.write_text("models:\n  b:\n    backend_url: http://two\n")
     reg.maybe_reload()
     assert "b" in reg.models
     assert "a" not in reg.models
@@ -20,10 +21,19 @@ def test_registry_reload(tmp_path):
 
 def test_registry_invalid(tmp_path):
     cfg = tmp_path / "models.yaml"
-    cfg.write_text("models:\n  a:\n    service_url: http://one\n")
+    cfg.write_text("models:\n  a:\n    backend_url: http://one\n")
     reg = Registry(str(cfg))
     time.sleep(0.1)
     cfg.write_text("models:\n  bad:\n    foo: bar\n")
     with pytest.raises(ValidationError):
         reg.maybe_reload()
     assert "a" in reg.models
+
+
+def test_env_applied(tmp_path, monkeypatch):
+    cfg = tmp_path / "models.yaml"
+    cfg.write_text("models:\n  a:\n    backend_url: http://one\n    env:\n      TEST_VAR: value\n")
+    monkeypatch.delenv("TEST_VAR", raising=False)
+    Registry(str(cfg))
+    assert os.environ["TEST_VAR"] == "value"
+    monkeypatch.delenv("TEST_VAR", raising=False)


### PR DESCRIPTION
## Summary
- support both vLLM and llama.cpp backends in config schema
- validate model URLs and positive limits via Pydantic
- document and test hot-reloading with env injection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f709a640832d8d017e0765042ecd