### PR TITLE
Add vLLM GPU compose file and runbook

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -118,7 +118,7 @@ def get_model_config(model: str) -> ModelConfig:
 
 
 async def proxy_request(path: str, payload: Dict[str, Any], stream: bool, model_cfg: ModelConfig, request: Request) -> StreamingResponse | JSONResponse:
-    url = model_cfg.backend_url + path
+    url = str(model_cfg.backend_url) + path
     headers = dict(request.headers)
     headers.pop("host", None)
     headers.update(model_cfg.headers)

--- a/config/models.vllm.yaml
+++ b/config/models.vllm.yaml
@@ -1,0 +1,4 @@
+models:
+  llama3-8b-instruct:
+    backend: vllm
+    backend_url: http://vllm-cuda:8000

--- a/docs/module-plan.md
+++ b/docs/module-plan.md
@@ -27,7 +27,7 @@ No training or full OpenAI platform clone; scope limited to `/v1/models`, `/v1/c
 
 ### M3. vLLM Backend (GPU)
 - Compose service for CUDA or ROCm with persistent HF cache and health checks.
-- Deliverables: `compose.vllm.yaml`, runbook, multi-GPU notes.
+- Deliverables: `vllm/compose.yaml`, runbook, multi-GPU notes.
 - Acceptance: gateway streams to vLLM container locally.
 
 ### M4. llama.cpp Backend (CPU/ARM)

--- a/docs/vllm-multi-gpu.md
+++ b/docs/vllm-multi-gpu.md
@@ -1,0 +1,27 @@
+# vLLM Multi-GPU Notes
+
+vLLM scales across multiple GPUs via tensor and pipeline parallelism. When using Docker Compose you can reserve more than one GPU and pass the appropriate arguments to the server.
+
+## Reserving GPUs
+Set the `GPU_COUNT` environment variable before starting the service:
+
+```bash
+GPU_COUNT=2 docker compose -f vllm/compose.yaml --profile cuda up -d
+```
+
+On ROCm hardware use the `rocm` profile instead of `cuda`.
+
+## Configuring vLLM
+vLLM requires an explicit tensor-parallel or pipeline-parallel size to leverage multiple devices. Provide it via `VLLM_ARGS` and append to the command:
+
+```bash
+GPU_COUNT=2 VLLM_ARGS="--tensor-parallel-size 2" \
+  docker compose -f vllm/compose.yaml --profile cuda up -d
+```
+
+For large models that do not fit on a single GPU, enable parallelism that matches `GPU_COUNT`.
+
+## Notes
+- Ensure all GPUs are of the same model and have high-speed interconnects.
+- NCCL is used for communication on NVIDIA; ROCm uses RCCL.
+- Distributed setups across multiple hosts are out of scope for this compose file.

--- a/docs/vllm-runbook.md
+++ b/docs/vllm-runbook.md
@@ -1,0 +1,74 @@
+# vLLM GPU Backend Runbook
+
+This runbook describes how to launch both the vLLM OpenAI-compatible server and the gateway on a single node with either NVIDIA (CUDA) or AMD (ROCm) GPUs using Docker Compose. The stack exposes a health endpoint and persists the Hugging Face cache to speed up subsequent runs.
+
+## Prerequisites
+- Docker Engine >= 24 with Compose V2
+- GPU drivers installed on the host (NVIDIA or ROCm)
+- At least one compatible GPU
+- Network access to download models from Hugging Face on first start
+
+Create a directory for the Hugging Face cache:
+
+```bash
+mkdir -p ./data/hf
+```
+
+## Launching the Services
+The compose file defines two profiles. Choose the one matching your hardware and start the gateway alongside the appropriate vLLM container.
+
+### NVIDIA / CUDA
+```bash
+docker compose -f vllm/compose.yaml --profile cuda up -d
+```
+
+### AMD / ROCm
+```bash
+docker compose -f vllm/compose.yaml --profile rocm up -d
+```
+
+On first launch Compose builds the vLLM service image from [`vllm/Dockerfile`](../vllm/Dockerfile), inheriting from the specified CUDA or ROCm base image.
+
+Environment variables allow customization:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VLLM_MODEL` | `NousResearch/Meta-Llama-3-8B-Instruct` | Model repository to serve |
+| `VLLM_PORT` | `8000` | vLLM host/container port |
+| `GATEWAY_PORT` | `8080` | Gateway host port |
+| `GPU_COUNT` | `1` | Number of GPUs to reserve |
+| `VLLM_ARGS` | `` | Additional arguments passed to vLLM |
+| `VLLM_IMAGE_CUDA` | `vllm/vllm-openai:v0.10.0` | CUDA base image |
+| `VLLM_IMAGE_ROCM` | `vllm/vllm-openai-rocm:v0.10.0` | ROCm base image |
+
+## Health Check
+Verify the vLLM server is ready:
+
+```bash
+curl -sf http://localhost:${VLLM_PORT:-8000}/health
+```
+
+## Integration with the Gateway
+`config/models.vllm.yaml` is mounted into the gateway container and already contains an entry pointing at the vLLM service:
+
+```yaml
+models:
+  llama3-8b-instruct:
+    backend: vllm
+    backend_url: http://vllm-cuda:8000  # or vllm-rocm
+```
+
+Stream a response through the gateway:
+
+```bash
+curl -N -X POST http://localhost:${GATEWAY_PORT:-8080}/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model": "llama3-8b-instruct", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+A streaming response indicates the gateway is routing requests to vLLM successfully.
+
+## Shutdown
+```bash
+docker compose -f vllm/compose.yaml down
+```

--- a/vllm/Dockerfile
+++ b/vllm/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+ARG BASE_IMAGE=vllm/vllm-openai:v0.10.0
+FROM ${BASE_IMAGE}
+
+ENV HF_HOME=/data/hf
+
+ENTRYPOINT ["python", "-m", "vllm.entrypoints.openai.api_server"]

--- a/vllm/compose.yaml
+++ b/vllm/compose.yaml
@@ -1,0 +1,69 @@
+version: "3.9"
+
+x-vllm-base: &vllm-base
+  command: >-
+    --model ${VLLM_MODEL:-NousResearch/Meta-Llama-3-8B-Instruct}
+    --port ${VLLM_PORT:-8000} ${VLLM_ARGS:-}
+  ports:
+    - "${VLLM_PORT:-8000}:${VLLM_PORT:-8000}"
+  environment:
+    HF_HOME: /data/hf
+  volumes:
+    - ../data/hf:/data/hf
+  healthcheck:
+    test: ["CMD-SHELL", "curl -fsS http://localhost:${VLLM_PORT:-8000}/health || exit 1"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 20s
+
+services:
+  gateway:
+    build: ../api
+    ports:
+      - "${GATEWAY_PORT:-8080}:8080"
+    environment:
+      MODELS_CONFIG: /config/models.yaml
+    volumes:
+      - ../config/models.vllm.yaml:/config/models.yaml:ro
+    depends_on:
+      vllm-cuda:
+        condition: service_healthy
+      vllm-rocm:
+        condition: service_healthy
+    profiles: ["cuda", "rocm"]
+
+  vllm-cuda:
+    <<: *vllm-base
+    build:
+      context: .
+      args:
+        BASE_IMAGE: ${VLLM_IMAGE_CUDA:-vllm/vllm-openai:v0.10.0}
+    profiles: ["cuda"]
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: ${GPU_COUNT:-1}
+              capabilities: [gpu]
+
+  vllm-rocm:
+    <<: *vllm-base
+    build:
+      context: .
+      args:
+        BASE_IMAGE: ${VLLM_IMAGE_ROCM:-vllm/vllm-openai-rocm:v0.10.0}
+    profiles: ["rocm"]
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - video
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: amd
+              count: ${GPU_COUNT:-1}
+              capabilities: [gpu]


### PR DESCRIPTION
## Summary
- Build vLLM CUDA/ROCm services from local Dockerfile with pinned v0.10.0 base images
- Document Dockerfile build and default image tags in runbook
- Move vLLM compose file under module directory and update docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897f91d1ddc832db5acf7c1fd0e4bc2