### PR TITLE
Enable multi-model concurrency with dual vLLM backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # modeltainer
 ModelTainer — One-command deploy for any LLM, anywhere. Run GPU (vLLM) or CPU/ARM (llama.cpp) models side-by-side via an OpenAI-compatible API. Hot-swap models with config only, scale from laptop to HPC, and compare outputs instantly.
+
+See [docs/ab-testing.md](docs/ab-testing.md) for running multiple models concurrently and A/B testing via the `model` field.
+
+The [multi-models-concurrency/compose.yaml](multi-models-concurrency/compose.yaml) example spins up two vLLM instances and a llama.cpp service alongside the gateway.

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,7 +1,14 @@
 models:
-  test-model:
+  test-model-a:
     backend: vllm
     backend_url: "http://localhost:8001"
+    headers:
+      x-test: "1"
+    limits:
+      max_tokens: 1000
+  test-model-b:
+    backend: vllm
+    backend_url: "http://localhost:8003"
     headers:
       x-test: "1"
     limits:

--- a/docs/ab-testing.md
+++ b/docs/ab-testing.md
@@ -1,0 +1,37 @@
+# A/B Testing with Multiple Models
+
+ModelTainer routes requests based on the `model` field. By defining distinct model IDs in `config/models.yaml`, multiple backends can run side by side to support A/B experiments.
+
+For a ready-to-run example that launches two vLLM services and a llama.cpp embedding server, see [../multi-models-concurrency/compose.yaml](../multi-models-concurrency/compose.yaml).
+
+## Example Configuration
+```yaml
+models:
+  test-model-a:
+    backend: vllm
+    backend_url: http://localhost:8001
+  test-model-b:
+    backend: vllm
+    backend_url: http://localhost:8003
+  embedding-model:
+    backend: llamacpp
+    backend_url: http://localhost:8002
+    embeddings: true
+```
+
+Each logical model name (`test-model-a`, `test-model-b`) points to a different backend process and port.
+
+## Sending Requests
+Switch models by changing the `model` field in the request body:
+
+```bash
+curl -s -X POST http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' -H "Authorization: Bearer $API_KEY" \
+  -d '{"model": "test-model-a", "messages": [{"role": "user", "content": "hi"}]}'
+
+curl -s -X POST http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' -H "Authorization: Bearer $API_KEY" \
+  -d '{"model": "test-model-b", "messages": [{"role": "user", "content": "hi"}]}'
+```
+
+Responses stream independently, enabling head-to-head comparison of the two model variants.

--- a/multi-models-concurrency/compose.yaml
+++ b/multi-models-concurrency/compose.yaml
@@ -1,0 +1,81 @@
+version: "3.9"
+
+x-vllm-base: &vllm-base
+  build:
+    context: ../vllm
+    args:
+      BASE_IMAGE: ${VLLM_IMAGE_CUDA:-vllm/vllm-openai:v0.10.0}
+  environment:
+    HF_HOME: /data/hf
+  volumes:
+    - ../data/hf:/data/hf
+  healthcheck:
+    test: ["CMD-SHELL", "curl -fsS http://localhost:${VLLM_PORT:-8000}/health || exit 1"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 20s
+  deploy:
+    resources:
+      reservations:
+        devices:
+          - driver: nvidia
+            count: ${GPU_COUNT:-1}
+            capabilities: [gpu]
+
+services:
+  gateway:
+    build: ../api
+    ports:
+      - "${GATEWAY_PORT:-8080}:8080"
+    environment:
+      MODELS_CONFIG: /config/models.yaml
+    volumes:
+      - ../config/models.yaml:/config/models.yaml:ro
+    depends_on:
+      vllm-a:
+        condition: service_healthy
+      vllm-b:
+        condition: service_healthy
+      llcpp:
+        condition: service_healthy
+
+  vllm-a:
+    <<: *vllm-base
+    environment:
+      VLLM_PORT: 8001
+      VLLM_MODEL: ${VLLM_MODEL_A:-NousResearch/Meta-Llama-3-8B-Instruct}
+    command: >-
+      --model ${VLLM_MODEL_A:-NousResearch/Meta-Llama-3-8B-Instruct}
+      --port 8001 ${VLLM_ARGS_A:-}
+    ports:
+      - "8001:8001"
+
+  vllm-b:
+    <<: *vllm-base
+    environment:
+      VLLM_PORT: 8003
+      VLLM_MODEL: ${VLLM_MODEL_B:-NousResearch/Meta-Llama-3-8B-Instruct}
+    command: >-
+      --model ${VLLM_MODEL_B:-NousResearch/Meta-Llama-3-8B-Instruct}
+      --port 8003 ${VLLM_ARGS_B:-}
+    ports:
+      - "8003:8003"
+
+  llcpp:
+    build: ../llama.cpp
+    command: >-
+      --model /models/${LLAMACPP_MODEL:-model.gguf}
+      -c ${LLAMACPP_CONTEXT:-4096}
+      --host 0.0.0.0
+      --port 8002
+    volumes:
+      - ../models:/models
+    ports:
+      - "8002:8002"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:8002/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s


### PR DESCRIPTION
## Summary
- move concurrency compose example into `multi-models-concurrency/compose.yaml`
- reference the compose example from README and A/B testing docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689827ad2ed8832d8e4cc9067761d975