### PR TITLE
Add Slurm template for vLLM with Apptainer

### DIFF
--- a/docs/slurm-vllm.md
+++ b/docs/slurm-vllm.md
@@ -1,0 +1,50 @@
+# vLLM on Slurm with Apptainer
+
+This guide outlines running the OpenAI‑compatible vLLM server on a Slurm GPU node using [Apptainer](https://apptainer.org/) to pull the upstream Docker image. It covers submitting the batch job, accessing the service port, and running multiple instances on an NVIDIA A100 with MIG.
+
+## Submit the Job
+
+1. Copy or customize [`scripts/slurm/run_vllm.sbatch`](../scripts/slurm/run_vllm.sbatch).
+2. Submit to Slurm:
+
+```bash
+sbatch scripts/slurm/run_vllm.sbatch
+```
+
+The script pulls `docker://vllm/vllm-openai:latest` and launches the server on the port defined by `VLLM_PORT` (default `8000`). Set `VLLM_MODEL` to choose a model.
+
+## Accessing the Service Port
+
+The vLLM server binds to `0.0.0.0` so the port is reachable from the compute node. Common access patterns:
+
+- **SSH tunnel from login node**
+  ```bash
+  ssh -L 8000:$(squeue -j <jobid> -h -o %N):8000 login.cluster
+  curl -sf http://localhost:8000/health
+  ```
+- **Node proxy / service node** – run a lightweight HTTP proxy (e.g. Nginx) on a trusted node that forwards requests to the compute node.
+- **Cluster service** – if the cluster provides an internal load balancer, register the compute node and port so other nodes can reach it directly.
+
+## Running on A100 with MIG
+
+Multiple vLLM services can share a single A100 by exposing MIG devices. Adjust `CUDA_VISIBLE_DEVICES` in the batch script to the MIG slice ID:
+
+```bash
+export CUDA_VISIBLE_DEVICES=MIG-GPU-<UUID>/gi0
+```
+
+Each job can target a different slice while sharing node resources. Confirm MIG devices with `nvidia-smi -L`.
+
+## Shutdown
+
+Cancel the job when finished:
+
+```bash
+scancel <jobid>
+```
+
+## Security Notes
+
+- Only forward ports through trusted networks.
+- Restrict job runtime and memory to prevent abuse.
+- Clear any cached model data between users if using shared scratch storage.

--- a/scripts/slurm/run_vllm.sbatch
+++ b/scripts/slurm/run_vllm.sbatch
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH --job-name=vllm
+#SBATCH --partition=gpu
+#SBATCH --gres=gpu:1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=16G
+#SBATCH --time=02:00:00
+#SBATCH --output=%x-%j.log
+
+# Optional: restrict to specific GPU or MIG slice
+# export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+
+module load apptainer
+
+MODEL=${VLLM_MODEL:-NousResearch/Meta-Llama-3-8B-Instruct}
+PORT=${VLLM_PORT:-8000}
+
+# Launch vLLM OpenAI-compatible server inside Apptainer
+apptainer exec --nv docker://vllm/vllm-openai:latest \
+  python3 -m vllm.entrypoints.openai.api_server \
+    --model "$MODEL" \
+    --host 0.0.0.0 \
+    --port "$PORT"


### PR DESCRIPTION
## Summary
- Add Slurm sbatch script using Apptainer to launch vLLM
- Document port access and MIG usage for cluster deployments

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68982bcf3f9c832d95d0c229985e41e6