### PR TITLE
Enforce API bearer auth and add security baseline docs

### DIFF
--- a/api/server.py
+++ b/api/server.py
@@ -167,14 +167,14 @@ async def health() -> Dict[str, Any]:
 
 
 @app.get("/v1/models")
-async def list_models() -> Dict[str, Any]:
+async def list_models(_: None = Depends(verify_api_key)) -> Dict[str, Any]:
     registry: Registry | None = getattr(app.state, "registry", None)
     data = [{"id": name, "object": "model"} for name in registry.models.keys()] if registry else []
     return {"data": data, "object": "list"}
 
 
 @app.post("/admin/reload")
-async def admin_reload() -> Dict[str, str]:
+async def admin_reload(_: None = Depends(verify_api_key)) -> Dict[str, str]:
     try:
         load_config()
     except Exception as exc:

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -1,0 +1,77 @@
+# Security Baseline
+
+## Gateway Authentication
+- The gateway enforces `Authorization: Bearer <token>` for every request. Set the token with the `API_KEY` environment variable.
+- Requests missing the header or presenting an invalid token receive `401 Unauthorized`.
+
+## Reverse Proxy Hardening
+Put the gateway behind a reverse proxy that terminates TLS, limits request rates and optionally restricts source IPs.
+
+### NGINX
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name example.com;
+
+    ssl_certificate     /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+    # Allow only trusted networks (optional)
+    allow 10.0.0.0/8;
+    deny all;
+
+    limit_req zone=gateway burst=10 nodelay;
+
+    location / {
+        proxy_pass http://gateway:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+limit_req_zone $binary_remote_addr zone=gateway:10m rate=5r/s;
+```
+
+### Traefik
+```yaml
+http:
+  routers:
+    gateway:
+      rule: Host(`example.com`)
+      service: gateway
+      entryPoints: ["https"]
+      middlewares: ["ratelimit", "ipallow"]
+  services:
+    gateway:
+      loadBalancer:
+        servers:
+          - url: "http://gateway:8080"
+  middlewares:
+    ratelimit:
+      rateLimit:
+        average: 5
+        burst: 10
+    ipallow:
+      ipWhiteList:
+        sourceRange:
+          - "10.0.0.0/8"
+```
+
+## Container Hardening
+Run containers with least privileges:
+
+```yaml
+services:
+  gateway:
+    image: your-image
+    read_only: true
+    user: 1000:1000
+    cap_drop: ["ALL"]
+    security_opt: ["no-new-privileges:true"]
+    mem_limit: 1g
+    pids_limit: 100
+```
+
+## Basic Security Checks
+- Scan images (`docker scan` or `trivy`).
+- Run linter/static analysis (`bandit`).
+- Perform port scans and fuzz endpoints for unexpected responses.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,11 +29,19 @@ def test_health():
 
 def test_models_endpoint():
     load_config()
-    resp = client.get("/v1/models")
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer test"})
     assert resp.status_code == 200
     body = resp.json()
     ids = [m["id"] for m in body["data"]]
     assert "test-model-a" in ids and "test-model-b" in ids
+
+
+def test_auth_required():
+    load_config()
+    resp = client.get("/v1/models")
+    assert resp.status_code == 401
+    resp = client.get("/v1/models", headers={"Authorization": "Bearer wrong"})
+    assert resp.status_code == 401
 
 
 def test_unknown_model():


### PR DESCRIPTION
## Summary
- require bearer token for model list and admin reload endpoints
- test auth failure cases
- document security best practices and reverse-proxy examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68982d067888832dae36595ed4383a8a