### PR TITLE
feat: update default models

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ ModelTainer — One-command deploy for any LLM, anywhere. Run GPU (vLLM) or CPU/
 See [docs/ab-testing.md](docs/ab-testing.md) for running multiple models concurrently and A/B testing via the `model` field.
 
 The [multi-models-concurrency/compose.yaml](multi-models-concurrency/compose.yaml) example spins up two vLLM instances and a llama.cpp service alongside the gateway.
+
+## Default Models
+
+The reference compose files ship with the following defaults:
+
+- **GPU (vLLM):** `openai/gpt-oss-20b` in `mxfp4` precision.
+- **CPU (llama.cpp):** `gemma-3-1b-it-Q4_K_M.gguf`.
+
+Override these by setting `VLLM_MODEL` or `LLAMACPP_MODEL` when launching the services.

--- a/config/models.llamacpp.yaml
+++ b/config/models.llamacpp.yaml
@@ -1,4 +1,4 @@
 models:
-  llama-cpp:
+  gemma-3-1b-it:
     backend: llamacpp
     backend_url: http://llcpp:8002

--- a/config/models.vllm.yaml
+++ b/config/models.vllm.yaml
@@ -1,4 +1,4 @@
 models:
-  llama3-8b-instruct:
+  gpt-oss-20b-it:
     backend: vllm
     backend_url: http://vllm-cuda:8000

--- a/llama.cpp/README.md
+++ b/llama.cpp/README.md
@@ -4,16 +4,16 @@ This setup runs the `llama-server` from [llama.cpp](https://github.com/ggml-org/
 
 ## Usage
 
-1. Place a GGUF model in the `models` directory at the repository root:
+1. Download the Gemma 3 1B (IT) model in `Q4_K_M` precision to the `models` directory:
    ```bash
    mkdir -p models
-   cp /path/to/your/model.gguf models/
+   huggingface-cli download unsloth/gemma-3-1b-it-GGUF --include "gemma-3-1b-it-Q4_K_M.gguf" --local-dir models
    ```
 2. Start the service and gateway:
    ```bash
-   LLAMACPP_MODEL=model.gguf docker compose -f llama.cpp/compose.yaml up -d
+   docker compose -f llama.cpp/compose.yaml up -d
    ```
-   * `LLAMACPP_MODEL` – filename of the model under `models/` (default: `model.gguf`)
+   * `LLAMACPP_MODEL` – override the model filename under `models/` (default: `gemma-3-1b-it-Q4_K_M.gguf`)
    * `LLAMACPP_PORT` – port to expose the server (default: `8002`)
    * `LLAMACPP_CONTEXT` – context length passed via `-c` (default: `4096`)
 

--- a/llama.cpp/compose.yaml
+++ b/llama.cpp/compose.yaml
@@ -16,7 +16,7 @@ services:
   llcpp:
     build: .
     command: >-
-      --model /models/${LLAMACPP_MODEL:-model.gguf}
+      --model /models/${LLAMACPP_MODEL:-gemma-3-1b-it-Q4_K_M.gguf}
       -c ${LLAMACPP_CONTEXT:-4096}
       --host 0.0.0.0
       --port ${LLAMACPP_PORT:-8002}

--- a/vllm/compose.yaml
+++ b/vllm/compose.yaml
@@ -2,7 +2,8 @@ version: "3.9"
 
 x-vllm-base: &vllm-base
   command: >-
-    --model ${VLLM_MODEL:-NousResearch/Meta-Llama-3-8B-Instruct}
+    --model ${VLLM_MODEL:-openai/gpt-oss-20b}
+    --quantization ${VLLM_QUANT:-mxfp4}
     --port ${VLLM_PORT:-8000} ${VLLM_ARGS:-}
   ports:
     - "${VLLM_PORT:-8000}:${VLLM_PORT:-8000}"


### PR DESCRIPTION
## Summary
- default vLLM service now loads `openai/gpt-oss-20b` using mxfp4 quantization
- default llama.cpp service uses `gemma-3-1b-it` GGUF in Q4_K_M precision
- document new defaults and how to download the Gemma model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689832077d30832db84b3d2b092dcb65