### PR TITLE
docs: add quickstart and troubleshooting guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,39 @@
 # modeltainer
 ModelTainer — One-command deploy for any LLM, anywhere. Run GPU (vLLM) or CPU/ARM (llama.cpp) models side-by-side via an OpenAI-compatible API. Hot-swap models with config only, scale from laptop to HPC, and compare outputs instantly.
 
-See [docs/ab-testing.md](docs/ab-testing.md) for running multiple models concurrently and A/B testing via the `model` field.
+## Quickstart
+1. Clone and enter the repository:
+   ```bash
+   git clone https://example.com/modeltainer.git && cd modeltainer
+   ```
+2. Start the default services:
+   ```bash
+   make up
+   ```
+3. Send a test request through the gateway:
+   ```bash
+   curl -N -X POST http://localhost:8080/v1/chat/completions \
+     -H 'Content-Type: application/json' \
+     -d '{"model": "llama3-8b-instruct", "messages": [{"role": "user", "content": "Hello"}]}'
+   ```
+   A streaming response indicates the stack is ready.
 
-The [multi-models-concurrency/compose.yaml](multi-models-concurrency/compose.yaml) example spins up two vLLM instances and a llama.cpp service alongside the gateway.
+### Notes
+- First start downloads models into `./data/hf`.
+- Stop the stack with `make down`.
 
 ## Default Models
-
 The reference compose files ship with the following defaults:
 
 - **GPU (vLLM):** `openai/gpt-oss-20b` in `mxfp4` precision.
 - **CPU (llama.cpp):** `gemma-3-1b-it-Q4_K_M.gguf`.
 
 Override these by setting `VLLM_MODEL` or `LLAMACPP_MODEL` when launching the services.
+
+## Further Reading
+- [Quickstart guide](docs/quickstart.md)
+- [Model swap guide](docs/model-swap.md)
+- [Troubleshooting tips](docs/troubleshooting.md)
+- [Resource sizing cheatsheet](docs/resource-sizing.md)
+- [A/B testing](docs/ab-testing.md)
+- [Multi-model compose example](multi-models-concurrency/compose.yaml)

--- a/docs/model-swap.md
+++ b/docs/model-swap.md
@@ -1,0 +1,25 @@
+# Model Swap Guide
+
+Change which models are served without rebuilding containers.
+
+## Swapping Models
+ModelTainer reads model choices from environment variables at startup:
+
+- **vLLM (GPU):** `VLLM_MODEL`
+- **llama.cpp (CPU/ARM):** `LLAMACPP_MODEL`
+
+Set them when launching the stack:
+
+```bash
+VLLM_MODEL="openai/gpt-4o-mini" LLAMACPP_MODEL="gemma-3-1b-it-Q4_K_M.gguf" make up
+```
+
+The gateway automatically reloads its configuration and exposes both models via the `model` field.
+
+## Adding Custom Configs
+To register additional models or backends, edit files under `config/` and restart the relevant services.
+
+## Notes
+- Model repositories must be accessible from the host; supply a Hugging Face token for gated models.
+- Changing `VLLM_MODEL` or `LLAMACPP_MODEL` triggers a fresh download into `./data/hf` if not cached.
+- Ensure GPUs have enough VRAM for the selected vLLM model; see the [resource sizing cheatsheet](resource-sizing.md).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,32 @@
+# Quickstart
+
+Bring up ModelTainer and serve an LLM behind an OpenAI-compatible API in minutes.
+
+## Prerequisites
+- Docker Engine \>= 24 with Compose V2
+- Internet access for the first model download
+- (Optional) [Hugging Face token](https://huggingface.co/settings/tokens) for gated models
+
+## Steps
+1. Clone the repository and change into the directory:
+   ```bash
+   git clone https://example.com/modeltainer.git && cd modeltainer
+   ```
+2. Start the default vLLM and llama.cpp services:
+   ```bash
+   make up
+   ```
+3. Verify the gateway is serving requests:
+   ```bash
+   curl -N -X POST http://localhost:8080/v1/chat/completions \
+     -H 'Content-Type: application/json' \
+     -d '{"model": "llama3-8b-instruct", "messages": [{"role": "user", "content": "Hello"}]}'
+   ```
+   A streaming response confirms the stack is running.
+
+For advanced options such as model selection or multi-model setups, see the [model swap guide](model-swap.md) and [A/B testing](ab-testing.md).
+
+## Notes
+- The first run downloads models into `./data/hf`, which can take several minutes.
+- Run `make down` to stop all services.
+- Default ports are 8080 for the gateway and 8000 for vLLM; adjust via environment variables if needed.

--- a/docs/resource-sizing.md
+++ b/docs/resource-sizing.md
@@ -1,0 +1,16 @@
+# Resource Sizing Cheatsheet
+
+Estimate hardware needs for common model configurations.
+
+| Model | Backend | Precision | Minimum VRAM | Notes |
+|-------|---------|-----------|--------------|-------|
+| `openai/gpt-oss-20b` | vLLM | mxfp4 | ~24 GB | Single GPU |
+| `NousResearch/Meta-Llama-3-8B-Instruct` | vLLM | fp16 | ~16 GB | Single GPU |
+| `gemma-3-1b-it-Q4_K_M.gguf` | llama.cpp | Q4_K_M | ~4 GB RAM | CPU/ARM |
+
+Adjust `GPU_COUNT` to spread models across multiple GPUs if available.
+
+## Notes
+- VRAM estimates assume no other processes share the GPU.
+- Higher precision (fp16, fp32) increases memory requirements.
+- For custom models, consult their documentation for exact sizing.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,29 @@
+# Troubleshooting
+
+Common issues when running ModelTainer.
+
+## Port Conflicts
+If ports `8080` (gateway) or `8000` (vLLM) are in use, change them when starting services:
+```bash
+GATEWAY_PORT=9090 VLLM_PORT=9000 make up
+```
+Verify with `docker ps` that the containers are bound to the desired ports.
+
+## VRAM Out of Memory
+vLLM requires sufficient GPU memory. If the container exits with OOM errors:
+- Choose a smaller model via `VLLM_MODEL`.
+- Reduce `GPU_COUNT` or other vLLM parameters.
+- Ensure no other processes are using the GPU.
+
+## Hugging Face Authentication
+Gated models require a Hugging Face token:
+```bash
+export HUGGING_FACE_HUB_TOKEN=hf_xxx
+make up
+```
+Tokens can also be placed in `./.env` for convenience.
+
+## Notes
+- Inspect container logs with `make logs` for additional details.
+- The Hugging Face cache lives under `./data/hf`; delete entries if downloads become corrupted.
+- Adjusting ports may require updating client configurations pointing at the API.


### PR DESCRIPTION
## Summary
- expand README with quickstart and links to new docs
- add guides for model swapping, troubleshooting, and resource sizing
- document quickstart steps for spinning up the stack

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898345da9e8832d9320a91704cd8616