### PR TITLE
Document GPT-OSS 20B IT as default vLLM model

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ ModelTainer delivers one‑command deployment for large language models on CPUs 
    ```bash
    curl -N -X POST http://localhost:8080/v1/chat/completions \
      -H 'Content-Type: application/json' \
-     -d '{"model": "llama3-8b-instruct", "messages": [{"role": "user", "content": "Hello"}]}'
+     -d '{"model": "gpt-oss-20b-it", "messages": [{"role": "user", "content": "Hello"}]}'
    ```
    A streaming response confirms everything is running.
 
 ### Configuration
 
 - The first run downloads models into `./data/hf`.
+- By default vLLM serves `openai/gpt-oss-20b-it` in `mxfp4` precision and llama.cpp serves `gemma-3-1b-it` quantized to `Q4_K_M`.
 - Override the defaults by setting `VLLM_MODEL` or `LLAMACPP_MODEL` before `make up`.
 - Stop and remove the stack with `make down`.
 

--- a/vllm/compose.yaml
+++ b/vllm/compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 x-vllm-base: &vllm-base
   command: >-
-    --model ${VLLM_MODEL:-openai/gpt-oss-20b}
+    --model ${VLLM_MODEL:-openai/gpt-oss-20b-it}
     --quantization ${VLLM_QUANT:-mxfp4}
     --port ${VLLM_PORT:-8000} ${VLLM_ARGS:-}
   ports:


### PR DESCRIPTION
## Summary
- default vLLM deployment now uses `openai/gpt-oss-20b-it` with MXFP4 quantization
- README details both default models: GPT-OSS 20B IT and Gemma 3 1B IT Q4_K_M

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898394548fc832d88a9344fb86b2253