### PR TITLE
fix: correct Makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: up down logs
 
 up:
-docker compose up -d
+	docker compose up -d
 
 down:
-docker compose down
+	docker compose down
 
 logs:
-docker compose logs -f
+	docker compose logs -f


### PR DESCRIPTION
## Summary
- add tab indentation before docker-compose commands in Makefile

## Testing
- `make -n up`
- `make up` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689847ba8be0832da6c69fabacf264b7