### PR TITLE
Add Apptainer model workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 models/
+images/
+run/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ ModelTainer delivers one‑command deployment for large language models on CPUs 
 - **Hot‑swappable models** – Change models via configuration only; no rebuilds required.
 - **Portable** – Runs on a laptop or scales out to multi‑node clusters using Docker Compose.
 - **Streaming responses** – Tokens stream as they are generated.
+- **Apptainer support** – Package models into transferable Apptainer images.
 
 ## Prerequisites
 
@@ -50,6 +51,7 @@ ModelTainer delivers one‑command deployment for large language models on CPUs 
 - [Security considerations](docs/Security.md)
 - [vLLM runbook](docs/vllm-runbook.md)
 - [Multi-model compose example](multi-models-concurrency/compose.yaml)
+- [Apptainer workflow](docs/apptainer.md)
 
 ## License
 

--- a/docs/apptainer.md
+++ b/docs/apptainer.md
@@ -1,0 +1,39 @@
+# Apptainer workflow
+
+ModelTainer can package each model into an [Apptainer](https://apptainer.org) image.
+The resulting `.sif` files are portable and can be shared with other
+machines without rebuilding.
+
+## Build an image with a model
+
+```bash
+scripts/apptainer/modeltainer.sh build vllm openai/gpt-oss-20b-it
+```
+
+The first run downloads the model and produces
+`images/vllm-openai_gpt-oss-20b-it.sif`.
+
+## Run the model API
+
+```bash
+scripts/apptainer/modeltainer.sh run vllm openai/gpt-oss-20b-it 8000
+```
+
+The API is now reachable on `http://localhost:8000`.
+Use different ports to start multiple models concurrently.
+
+## Stop a running model
+
+```bash
+scripts/apptainer/modeltainer.sh stop vllm openai/gpt-oss-20b-it
+```
+
+Stopping frees GPU memory. Restarting the same model later does not
+require a rebuild.
+
+## Share the image
+
+Copy the generated `.sif` file from `images/` to another host and run it
+with the same script. No source repository or internet access is required
+on the target machine.
+

--- a/scripts/apptainer/modeltainer.sh
+++ b/scripts/apptainer/modeltainer.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# Build and run Apptainer images for vLLM and llama.cpp models.
+#
+# Usage:
+#   modeltainer.sh build <vllm|llama> <model>
+#   modeltainer.sh run   <vllm|llama> <model> [port]
+#   modeltainer.sh stop  <vllm|llama> <model>
+#
+# Images are stored under ./images and can be copied to other machines
+# for reuse. Running models keep PID files under ./run so they can be
+# stopped later.
+
+set -euo pipefail
+
+ACTION=${1:-}
+ENGINE=${2:-}
+MODEL=${3:-}
+PORT=${4:-8000}
+
+if [[ -z "$ACTION" || -z "$ENGINE" || -z "$MODEL" ]]; then
+  echo "Usage: $0 <build|run|stop> <vllm|llama> <model> [port]" >&2
+  exit 1
+fi
+
+IMAGE_DIR="${IMAGE_DIR:-images}"
+RUN_DIR="${RUN_DIR:-run}"
+mkdir -p "$IMAGE_DIR" "$RUN_DIR"
+
+SIF="$IMAGE_DIR/${ENGINE}-$(echo "$MODEL" | tr '/' '_').sif"
+PID_FILE="$RUN_DIR/$(basename "$SIF").pid"
+LOG_FILE="$RUN_DIR/$(basename "$SIF").log"
+
+build_image() {
+  if [[ -f "$SIF" ]]; then
+    echo "Image $SIF already exists; skipping build"
+    return
+  fi
+
+  tmpdef=$(mktemp)
+  case "$ENGINE" in
+    vllm)
+      cat > "$tmpdef" <<EOF_DEF
+Bootstrap: docker
+From: vllm/vllm-openai:latest
+
+%post
+    pip install --no-cache-dir huggingface_hub
+    python3 - <<'PY'
+from huggingface_hub import snapshot_download
+snapshot_download(repo_id="$MODEL", local_dir="/models/$MODEL")
+PY
+
+%startscript
+    PORT=\${PORT:-8000}
+    exec python3 -m vllm.entrypoints.openai.api_server \\
+        --model "/models/$MODEL" \\
+        --host 0.0.0.0 \\
+        --port "\$PORT"
+EOF_DEF
+      ;;
+    llama)
+      cat > "$tmpdef" <<EOF_DEF
+Bootstrap: docker
+From: ghcr.io/ggerganov/llama.cpp:server
+
+%post
+    pip install --no-cache-dir huggingface_hub
+    python3 - <<'PY'
+from huggingface_hub import snapshot_download
+snapshot_download(repo_id="$MODEL", local_dir="/models/$MODEL")
+PY
+
+%startscript
+    PORT=\${PORT:-8000}
+    MODEL_FILE=\$(find /models/$MODEL -name '*.gguf' | head -n 1)
+    exec /usr/local/bin/server -m "\$MODEL_FILE" -p "\$PORT" --host 0.0.0.0
+EOF_DEF
+      ;;
+    *)
+      echo "Unknown engine: $ENGINE" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "Building Apptainer image $SIF"
+  apptainer build "$SIF" "$tmpdef"
+  rm -f "$tmpdef"
+}
+
+run_image() {
+  echo "Starting $SIF on port $PORT"
+  apptainer run --nv --env PORT=$PORT "$SIF" >"$LOG_FILE" 2>&1 &
+  echo $! > "$PID_FILE"
+  echo "PID $(cat $PID_FILE)"
+}
+
+stop_image() {
+  if [[ -f "$PID_FILE" ]]; then
+    kill $(cat "$PID_FILE") && rm -f "$PID_FILE"
+    echo "Stopped $(basename "$SIF")"
+  else
+    echo "No running process for $(basename "$SIF")" >&2
+  fi
+}
+
+case "$ACTION" in
+  build)
+    build_image
+    ;;
+  run)
+    build_image
+    run_image
+    ;;
+  stop)
+    stop_image
+    ;;
+  *)
+    echo "Unknown action: $ACTION" >&2
+    exit 1
+    ;;
+esac
+
+


### PR DESCRIPTION
## Summary
- add `scripts/apptainer/modeltainer.sh` to build and run model-specific Apptainer images
- document Apptainer-based workflow for shareable model images
- mention Apptainer support in README and ignore generated image directories

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898515f9b94832daaf421f71f4ca86f