### PR TITLE
Use latest tags for base Docker images

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:latest
 
 WORKDIR /app
 COPY requirements.txt /app/requirements.txt

--- a/llama.cpp/Dockerfile
+++ b/llama.cpp/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMAGE=ghcr.io/ggerganov/llama.cpp:server
+ARG BASE_IMAGE=ghcr.io/ggerganov/llama.cpp:latest
 FROM ${BASE_IMAGE}
 
 # The base image already sets entrypoint to llama-server

--- a/vllm/Dockerfile
+++ b/vllm/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG BASE_IMAGE=vllm/vllm-openai:v0.10.0
+ARG BASE_IMAGE=vllm/vllm-openai:latest
 FROM ${BASE_IMAGE}
 
 ENV HF_HOME=/data/hf


### PR DESCRIPTION
## Summary
- Switch API service to `python:latest` base image
- Adopt `latest` tags for llama.cpp and vLLM images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689859b616ec832d8270504a92fa7867