### PR TITLE
Ensure Makefile uses available Python interpreter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+PYTHON := $(shell command -v python3 2>/dev/null || command -v python)
+
 .PHONY: up down logs print-models
 
 print-models:
-	@python scripts/print_models.py
+	@$(PYTHON) scripts/print_models.py
 
 up: print-models
 	docker compose up -d


### PR DESCRIPTION
## Summary
- resolve `make up` failing when `python` is unavailable by detecting an installed interpreter
- route model-printing to the detected Python executable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68985b4a5f88832dbcfd1f2a9aa5dd93