### PR TITLE
feat: add nvidia docker build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ ModelTainer delivers one‑command deployment for large language models on CPUs 
 - **Portable** – Runs on a laptop or scales out to multi‑node clusters using Docker Compose.
 - **Streaming responses** – Tokens stream as they are generated.
 - **Apptainer support** – Package models into transferable Apptainer images.
+- **NVIDIA Docker support** – Build GPU-enabled images with a user-defined
+  NVIDIA Docker base version.
 
 ## Prerequisites
 
@@ -53,6 +55,7 @@ ModelTainer delivers one‑command deployment for large language models on CPUs 
 - [vLLM runbook](docs/vllm-runbook.md)
 - [Multi-model compose example](multi-models-concurrency/compose.yaml)
 - [Apptainer workflow](docs/apptainer.md)
+- [NVIDIA Docker workflow](docs/nvidia-docker.md)
 
 ## License
 

--- a/config/docker.yaml
+++ b/config/docker.yaml
@@ -1,0 +1,1 @@
+nvidia_docker_version: "v0.10.0"

--- a/docs/nvidia-docker.md
+++ b/docs/nvidia-docker.md
@@ -1,0 +1,43 @@
+# NVIDIA Docker workflow
+
+ModelTainer can also package each model into a standalone NVIDIA Docker image.
+The resulting images can be transferred to other machines with compatible
+GPU drivers.
+
+## Build an image with a model
+
+```bash
+scripts/docker/modeltainer.sh build vllm openai/gpt-oss-20b-it
+```
+
+The script reads `config/docker.yaml` to determine the base image tag. The
+default version is `v0.10.0`, but you can adjust it:
+
+```yaml
+# config/docker.yaml
+nvidia_docker_version: "v0.10.0"
+```
+
+## Run the model API
+
+```bash
+scripts/docker/modeltainer.sh run vllm openai/gpt-oss-20b-it 8000
+```
+
+The API is now reachable on `http://localhost:8000`.
+Use different ports to start multiple models concurrently.
+
+## Stop a running model
+
+```bash
+scripts/docker/modeltainer.sh stop vllm openai/gpt-oss-20b-it 8000
+```
+
+Stopping frees GPU memory. Restarting the same model later does not
+require a rebuild.
+
+## Share the image
+
+Copy the generated Docker image with `docker save` and load it on another
+host. The `nvidia_docker_version` in `config/docker.yaml` ensures the correct
+base image is used when rebuilding.

--- a/scripts/docker/modeltainer.sh
+++ b/scripts/docker/modeltainer.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# Build and run NVIDIA Docker images for vLLM and llama.cpp models.
+#
+# Usage:
+#   modeltainer.sh build <vllm|llama> <model>
+#   modeltainer.sh run   <vllm|llama> <model> [port]
+#   modeltainer.sh stop  <vllm|llama> <model> [port]
+#
+# The NVIDIA Docker base image version is read from config/docker.yaml
+# under the key `nvidia_docker_version`.
+
+set -euo pipefail
+
+ACTION=${1:-}
+ENGINE=${2:-}
+MODEL=${3:-}
+PORT=${4:-8000}
+
+if [[ -z "$ACTION" || -z "$ENGINE" || -z "$MODEL" ]]; then
+  echo "Usage: $0 <build|run|stop> <vllm|llama> <model> [port]" >&2
+  exit 1
+fi
+
+ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
+CONFIG_FILE="$ROOT_DIR/../config/docker.yaml"
+NVIDIA_VERSION=$(python3 - <<'PY'
+import yaml,sys
+from pathlib import Path
+cfg = Path(sys.argv[1])
+if cfg.is_file():
+    data = yaml.safe_load(cfg.read_text()) or {}
+    print(data.get("nvidia_docker_version", "latest"))
+else:
+    print("latest")
+PY
+"$CONFIG_FILE")
+
+IMAGE_NAME="modeltainer-${ENGINE}-$(echo "$MODEL" | tr '/' '-')"
+TAG="$NVIDIA_VERSION"
+CONTAINER_NAME="$IMAGE_NAME-$PORT"
+
+build_image() {
+  if docker image inspect "$IMAGE_NAME:$TAG" >/dev/null 2>&1; then
+    echo "Image $IMAGE_NAME:$TAG already exists; skipping build"
+    return
+  fi
+  tmpdir=$(mktemp -d)
+  case "$ENGINE" in
+    vllm)
+      cat >"$tmpdir/Dockerfile" <<EOF_DOCKER
+FROM vllm/vllm-openai:$NVIDIA_VERSION
+RUN pip install --no-cache-dir huggingface_hub && \\
+    python3 - <<'PY'
+from huggingface_hub import snapshot_download
+snapshot_download(repo_id="$MODEL", local_dir="/models/$MODEL")
+PY
+ENV PORT=8000
+CMD bash -lc 'python3 -m vllm.entrypoints.openai.api_server --model /models/$MODEL --host 0.0.0.0 --port $PORT'
+EOF_DOCKER
+      ;;
+    llama)
+      cat >"$tmpdir/Dockerfile" <<EOF_DOCKER
+FROM ghcr.io/ggerganov/llama.cpp:server
+RUN pip install --no-cache-dir huggingface_hub && \\
+    python3 - <<'PY'
+from huggingface_hub import snapshot_download
+snapshot_download(repo_id="$MODEL", local_dir="/models/$MODEL")
+PY
+ENV PORT=8000
+CMD bash -lc 'MODEL_FILE=$(find /models/$MODEL -name "*.gguf" | head -n 1); \ \
+  exec /usr/local/bin/server -m "$MODEL_FILE" -p $PORT --host 0.0.0.0'
+EOF_DOCKER
+      ;;
+    *)
+      echo "Unknown engine: $ENGINE" >&2
+      exit 1
+      ;;
+  esac
+  echo "Building Docker image $IMAGE_NAME:$TAG"
+  docker build -t "$IMAGE_NAME:$TAG" "$tmpdir"
+  rm -rf "$tmpdir"
+}
+
+run_image() {
+  echo "Starting $IMAGE_NAME:$TAG on port $PORT"
+  docker run --gpus all -d --rm \
+    -p "$PORT:$PORT" \
+    --name "$CONTAINER_NAME" \
+    -e PORT="$PORT" \
+    "$IMAGE_NAME:$TAG" >/dev/null
+  echo "Container $CONTAINER_NAME started"
+}
+
+stop_image() {
+  if docker ps -a --format '{{.Names}}' | grep -q "^$CONTAINER_NAME$"; then
+    docker stop "$CONTAINER_NAME" >/dev/null
+    echo "Stopped $CONTAINER_NAME"
+  else
+    echo "No running container named $CONTAINER_NAME" >&2
+  fi
+}
+
+case "$ACTION" in
+  build)
+    build_image
+    ;;
+  run)
+    build_image
+    run_image
+    ;;
+  stop)
+    stop_image
+    ;;
+  *)
+    echo "Unknown action: $ACTION" >&2
+    exit 1
+    ;;
+ESAC


### PR DESCRIPTION
## Summary
- add configurable NVIDIA Docker version in `config/docker.yaml`
- provide `scripts/docker/modeltainer.sh` to build and run GPU images
- document NVIDIA Docker workflow and reference it in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68985f588a18832da6deaa4e71ccdaea