### PR TITLE
Add docs index and standardize security guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,7 @@ ModelTainer delivers one‑command deployment for large language models on CPUs 
 
 ## Documentation
 
-- [Quickstart guide](docs/quickstart.md)
-- [Model swap guide](docs/model-swap.md)
-- [Resource sizing cheatsheet](docs/resource-sizing.md)
-- [Troubleshooting tips](docs/troubleshooting.md)
-- [A/B testing](docs/ab-testing.md)
-- [Security considerations](docs/Security.md)
-- [vLLM runbook](docs/vllm-runbook.md)
-- [Apptainer workflow](docs/apptainer.md)
-- [NVIDIA Docker workflow](docs/nvidia-docker.md)
+See the [documentation index](docs/README.md) for guides on quickstart, security, model swapping, troubleshooting, and more.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,16 @@
+# Documentation Index
+
+Guides for deploying and operating ModelTainer:
+
+- [Quickstart](quickstart.md)
+- [Security baseline](security.md)
+- [Model swap guide](model-swap.md)
+- [A/B testing](ab-testing.md)
+- [Resource sizing cheatsheet](resource-sizing.md)
+- [Troubleshooting tips](troubleshooting.md)
+- [vLLM runbook](vllm-runbook.md)
+- [vLLM on multiple GPUs](vllm-multi-gpu.md)
+- [SLURM with vLLM](slurm-vllm.md)
+- [Apptainer workflow](apptainer.md)
+- [NVIDIA Docker workflow](nvidia-docker.md)
+- [Module plan](module-plan.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,11 +1,13 @@
 # Security Baseline
 
+ModelTainer ships with minimal defaults. Harden deployments as follows.
+
 ## Gateway Authentication
-- The gateway enforces `Authorization: Bearer <token>` for every request. Set the token with the `API_KEY` environment variable.
-- Requests missing the header or presenting an invalid token receive `401 Unauthorized`.
+- Set an `API_KEY` environment variable and require `Authorization: Bearer <token>` on every request.
+- Reject missing or invalid tokens with `401 Unauthorized`.
 
 ## Reverse Proxy Hardening
-Put the gateway behind a reverse proxy that terminates TLS, limits request rates and optionally restricts source IPs.
+Place the gateway behind a TLS-terminating reverse proxy that limits request rates and optionally restricts source IP ranges.
 
 ### NGINX
 ```nginx
@@ -57,7 +59,7 @@ http:
 ```
 
 ## Container Hardening
-Run containers with least privileges:
+Run containers with least privilege.
 
 ```yaml
 services:
@@ -73,5 +75,5 @@ services:
 
 ## Basic Security Checks
 - Scan images (`docker scan` or `trivy`).
-- Run linter/static analysis (`bandit`).
-- Perform port scans and fuzz endpoints for unexpected responses.
+- Run static analysis (`bandit`).
+- Port-scan and fuzz endpoints for unexpected responses.


### PR DESCRIPTION
## Summary
- rename `Security.md` to `security.md` and expand security baseline guidance
- add `docs/README.md` index consolidating documentation links
- point project README to the docs index

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689862429604832da3e987a4645e66ca