### PR TITLE
docs: refresh README and quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ ModelTainer delivers one‑command deployment for large language models on CPUs 
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/) and Docker Compose
+- [Docker](https://docs.docker.com/get-docker/) Engine \>= 24 with Compose V2
 - Git
+- (Optional) [Hugging Face token](https://huggingface.co/settings/tokens) for gated models
 
 ## Quickstart
 
@@ -24,7 +25,17 @@ ModelTainer delivers one‑command deployment for large language models on CPUs 
    git clone https://github.com/sirirajgenomics/modeltainer
    cd modeltainer
    ```
-2. Start your LLM backends (e.g., vLLM and llama.cpp) separately. They must expose endpoints matching the URLs in `config/models.yaml`. If VRAM allows, launch multiple Docker or Apptainer containers to serve several models at once.
+2. Start example LLM backends so the gateway has targets to proxy. The commands below launch a GPU vLLM service and a CPU llama.cpp service:
+   ```bash
+   # Download the Gemma model required by llama.cpp
+   mkdir -p models
+   huggingface-cli download unsloth/gemma-3-1b-it-GGUF --include "gemma-3-1b-it-Q4_K_M.gguf" --local-dir models
+
+   # Start the backends
+   docker compose -f vllm/compose.yaml --profile cuda up -d vllm-cuda
+   docker compose -f llama.cpp/compose.yaml up -d llcpp
+   ```
+   The services expose `http://vllm:8000` and `http://llcpp:8002`, matching the defaults in `config/models.yaml`.
 3. Launch the gateway and supporting services:
    ```bash
    make up
@@ -38,11 +49,11 @@ ModelTainer delivers one‑command deployment for large language models on CPUs 
    ```
    A streaming response confirms everything is running.
 
-### Configuration
+### Configuration and Cleanup
 
 - Ensure your LLM containers serve the models referenced in `config/models.yaml`.
 - The `make up` command prints the configured models so you can verify endpoints before startup.
-- Stop and remove the gateway stack with `make down`.
+- Stop the gateway with `make down` and remove backend containers with `docker compose -f <file> down`.
 
 ## Documentation
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,17 +10,26 @@ Bring up ModelTainer and serve an LLM behind an OpenAI-compatible API in minutes
 ## Steps
 1. Clone the repository and change into the directory:
    ```bash
-   git clone https://example.com/modeltainer.git && cd modeltainer
+   git clone https://github.com/sirirajgenomics/modeltainer.git
+   cd modeltainer
    ```
-2. Start the default vLLM and llama.cpp services:
+2. Start example backends so the gateway has models to proxy. These commands launch vLLM on a GPU and llama.cpp on the CPU:
+   ```bash
+   mkdir -p models
+   huggingface-cli download unsloth/gemma-3-1b-it-GGUF --include "gemma-3-1b-it-Q4_K_M.gguf" --local-dir models
+
+   docker compose -f vllm/compose.yaml --profile cuda up -d vllm-cuda
+   docker compose -f llama.cpp/compose.yaml up -d llcpp
+   ```
+3. Bring up the gateway:
    ```bash
    make up
    ```
-3. Verify the gateway is serving requests:
+4. Verify the gateway is serving requests:
    ```bash
    curl -N -X POST http://localhost:8080/v1/chat/completions \
      -H 'Content-Type: application/json' \
-     -d '{"model": "llama3-8b-instruct", "messages": [{"role": "user", "content": "Hello"}]}'
+     -d '{"model": "gpt-oss-20b-it", "messages": [{"role": "user", "content": "Hello"}]}'
    ```
    A streaming response confirms the stack is running.
 


### PR DESCRIPTION
## Summary
- clarify prerequisites and backend startup instructions in README
- update quickstart doc to launch example vLLM and llama.cpp services before starting the gateway

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898af87099c832d8612d335aec56a42