### PR TITLE
feat: default llama.cpp model gpt-oss-20b

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ ModelTainer delivers one‑command deployment for large language models on CPUs 
    ```
 2. Start example LLM backends so the gateway has targets to proxy. The commands below launch a GPU vLLM service and a CPU llama.cpp service:
    ```bash
-   # Download the Gemma model required by llama.cpp
+   # Download the GPT-OSS 20B model required by llama.cpp
    mkdir -p models
-   huggingface-cli download unsloth/gemma-3-1b-it-GGUF --include "gemma-3-1b-it-Q4_K_M.gguf" --local-dir models
+   huggingface-cli download ggml-org/gpt-oss-20b-GGUF --include "gpt-oss-20b-mxfp4.gguf" --local-dir models
 
    # Start the backends
    docker compose -f vllm/compose.yaml --profile cuda up -d vllm-cuda

--- a/config/models.llamacpp.yaml
+++ b/config/models.llamacpp.yaml
@@ -1,4 +1,4 @@
 models:
-  gemma-3-1b-it:
+  gpt-oss-20b:
     backend: llamacpp
     backend_url: http://llcpp:8002

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -2,7 +2,7 @@ models:
   gpt-oss-20b-it:
     backend: vllm
     backend_url: "http://vllm:8000"
-  gemma-3-1b-it:
+  gpt-oss-20b:
     backend: llamacpp
     backend_url: "http://llcpp:8002"
     embeddings: true

--- a/docs/model-swap.md
+++ b/docs/model-swap.md
@@ -11,7 +11,7 @@ ModelTainer reads model choices from environment variables at startup:
 Set them when launching the stack:
 
 ```bash
-VLLM_MODEL="openai/gpt-4o-mini" LLAMACPP_MODEL="gemma-3-1b-it-Q4_K_M.gguf" make up
+VLLM_MODEL="openai/gpt-4o-mini" LLAMACPP_MODEL="gpt-oss-20b-mxfp4.gguf" make up
 ```
 
 The gateway automatically reloads its configuration and exposes both models via the `model` field.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ Bring up ModelTainer and serve an LLM behind an OpenAI-compatible API in minutes
 2. Start example backends so the gateway has models to proxy. These commands launch vLLM on a GPU and llama.cpp on the CPU:
    ```bash
    mkdir -p models
-   huggingface-cli download unsloth/gemma-3-1b-it-GGUF --include "gemma-3-1b-it-Q4_K_M.gguf" --local-dir models
+   huggingface-cli download ggml-org/gpt-oss-20b-GGUF --include "gpt-oss-20b-mxfp4.gguf" --local-dir models
 
    docker compose -f vllm/compose.yaml --profile cuda up -d vllm-cuda
    docker compose -f llama.cpp/compose.yaml up -d llcpp

--- a/docs/resource-sizing.md
+++ b/docs/resource-sizing.md
@@ -6,7 +6,7 @@ Estimate hardware needs for common model configurations.
 |-------|---------|-----------|--------------|-------|
 | `openai/gpt-oss-20b` | vLLM | mxfp4 | ~24 GB | Single GPU |
 | `NousResearch/Meta-Llama-3-8B-Instruct` | vLLM | fp16 | ~16 GB | Single GPU |
-| `gemma-3-1b-it-Q4_K_M.gguf` | llama.cpp | Q4_K_M | ~4 GB RAM | CPU/ARM |
+| `gpt-oss-20b-mxfp4.gguf` | llama.cpp | mxfp4 | ~10 GB RAM | CPU/ARM |
 
 Adjust `GPU_COUNT` to spread models across multiple GPUs if available.
 

--- a/llama.cpp/README.md
+++ b/llama.cpp/README.md
@@ -4,16 +4,16 @@ This setup runs the `llama-server` from [llama.cpp](https://github.com/ggml-org/
 
 ## Usage
 
-1. Download the Gemma 3 1B (IT) model in `Q4_K_M` precision to the `models` directory:
+1. Download the GPT-OSS 20B model in `mxfp4` precision to the `models` directory:
    ```bash
    mkdir -p models
-   huggingface-cli download unsloth/gemma-3-1b-it-GGUF --include "gemma-3-1b-it-Q4_K_M.gguf" --local-dir models
+   huggingface-cli download ggml-org/gpt-oss-20b-GGUF --include "gpt-oss-20b-mxfp4.gguf" --local-dir models
    ```
 2. Start the service and gateway:
    ```bash
    docker compose -f llama.cpp/compose.yaml up -d
    ```
-   * `LLAMACPP_MODEL` – override the model filename under `models/` (default: `gemma-3-1b-it-Q4_K_M.gguf`)
+   * `LLAMACPP_MODEL` – override the model filename under `models/` (default: `gpt-oss-20b-mxfp4.gguf`)
    * `LLAMACPP_PORT` – port to expose the server (default: `8002`)
    * `LLAMACPP_CONTEXT` – context length passed via `-c` (default: `4096`)
 

--- a/llama.cpp/compose.yaml
+++ b/llama.cpp/compose.yaml
@@ -16,7 +16,7 @@ services:
   llcpp:
     build: .
     command: >-
-      --model /models/${LLAMACPP_MODEL:-gemma-3-1b-it-Q4_K_M.gguf}
+      --model /models/${LLAMACPP_MODEL:-gpt-oss-20b-mxfp4.gguf}
       -c ${LLAMACPP_CONTEXT:-4096}
       --host 0.0.0.0
       --port ${LLAMACPP_PORT:-8002}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,7 @@ def test_health():
     body = resp.json()
     assert body["status"] == "ok"
     assert "gpt-oss-20b-it" in body["models"]
-    assert "gemma-3-1b-it" in body["models"]
+    assert "gpt-oss-20b" in body["models"]
 
 
 def test_models_endpoint():
@@ -33,7 +33,7 @@ def test_models_endpoint():
     assert resp.status_code == 200
     body = resp.json()
     ids = [m["id"] for m in body["data"]]
-    assert "gpt-oss-20b-it" in ids and "gemma-3-1b-it" in ids
+    assert "gpt-oss-20b-it" in ids and "gpt-oss-20b" in ids
 
 
 def test_auth_required():
@@ -115,7 +115,7 @@ def test_concurrent_models():
     app.state.client = async_client
 
     payload_a = {"model": "gpt-oss-20b-it", "messages": [{"role": "user", "content": "hi"}]}
-    payload_b = {"model": "gemma-3-1b-it", "messages": [{"role": "user", "content": "hi"}]}
+    payload_b = {"model": "gpt-oss-20b", "messages": [{"role": "user", "content": "hi"}]}
 
     async def run():
         transport = httpx.ASGITransport(app=app)


### PR DESCRIPTION
## Summary
- use gpt-oss-20b GGUF as the default llama.cpp model
- document the new GGUF and update model swap instructions
- align tests with the new default model

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689948bb5dc8832da11f3d5dc08ed616